### PR TITLE
Add a filter to use get intel machines

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,10 @@ data "aws_ami" "tf_data_ami_ubuntu" {
     name = "name"
     values = [var.ami_name]
   }
+  filter {
+    name = "architecture"
+    values = ["x86_64"]
+  }
 }
 
 data "aws_vpc" "tf_data_vpc" {


### PR DESCRIPTION
- Latest ubuntu ami had only intel architecture